### PR TITLE
Update HADS urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,11 +201,11 @@ List of Sources URLs
 
 ### [HADS](http://www.nws.noaa.gov/ohd/hads/)
 #### Pull stations Information
-* http://amazon.nws.noaa.gov/hads/goog_earth/ - used to get the list of state URLs
-* http://amazon.nws.noaa.gov/cgi-bin/hads/interactiveDisplays/displayMetaData.pl?table=dcp&nesdis_id= - used to pull station information. Needs the stations id or foreign id at the end of the URL
+* http://hads.ncep.noaa.gov/hads/goog_earth/ - used to get the list of state URLs
+* http://hads.ncep.noaa.gov/cgi-bin/hads/interactiveDisplays/displayMetaData.pl?table=dcp&nesdis_id= - used to pull station information. Needs the stations id or foreign id at the end of the URL
 
 #### Observation Retrieval
-* http://amazon.nws.noaa.gov/nexhads2/servlet/DecodedData - pull observations for a station. A POST request with the needed values pairs of:
+* http://hads.ncep.noaa.gov/nexhads2/servlet/DecodedData - pull observations for a station. A POST request with the needed values pairs of:
 
 1. state = nil
 1. hsa = nil

--- a/sensor-web-harvester-source/src/main/scala/com/axiomalaska/sos/harvester/source/SourceUrls.scala
+++ b/sensor-web-harvester-source/src/main/scala/com/axiomalaska/sos/harvester/source/SourceUrls.scala
@@ -2,10 +2,10 @@ package com.axiomalaska.sos.harvester.source
 
 object SourceUrls {
 
-  val HADS_OBSERVATION_RETRIEVAL = "http://amazon.nws.noaa.gov/nexhads2/servlet/DecodedData"
-  val HADS_COLLECTION_STATE_URLS = "http://amazon.nws.noaa.gov/hads/goog_earth/"
-  val HADS_STATE_URL_TEMPLATE = "http://amazon.nws.noaa.gov/hads/charts/%s.html"
-  val HADS_STATION_INFORMATION = "http://amazon.nws.noaa.gov/cgi-bin/hads/interactiveDisplays/displayMetaData.pl?table=dcp&nesdis_id="
+  val HADS_OBSERVATION_RETRIEVAL = "http://hads.ncep.noaa.gov/nexhads2/servlet/DecodedData"
+  val HADS_COLLECTION_STATE_URLS = "http://hads.ncep.noaa.gov/hads/goog_earth/"
+  val HADS_STATE_URL_TEMPLATE = "http://hads.ncep.noaa.gov/hads/charts/%s.html"
+  val HADS_STATION_INFORMATION = "http://hads.ncep.noaa.gov/cgi-bin/hads/interactiveDisplays/displayMetaData.pl?table=dcp&nesdis_id="
 
   val NDBC_SOS = "http://sdf.ndbc.noaa.gov/sos/server.php"
 

--- a/sensor-web-harvester-source/src/main/scala/com/axiomalaska/sos/harvester/source/stationupdater/HadsStationUpdater.scala
+++ b/sensor-web-harvester-source/src/main/scala/com/axiomalaska/sos/harvester/source/stationupdater/HadsStationUpdater.scala
@@ -213,7 +213,6 @@ class HadsStationUpdater(
     } else {
       Nil
     }
-//    List("http://amazon.nws.noaa.gov/hads/charts/AK.html")
   }
 
   private def getStateUrls(): List[String] = {


### PR DESCRIPTION
The URL "http://amazon.nws.noaa.gov" that is used for the HADS collector has been changed to "https://hads.ncep.noaa.gov".